### PR TITLE
conditionally handle L.Evented/L.MixinEvents

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ L.Control.SplitMap = L.Control.extend({
 
   setPosition: noop,
 
-  includes: L.Mixin.Events,
+  includes: L.version.split(".")[0] === '1' ? L.Evented.prototype : L.Mixin.Events,
 
   addTo: function (map) {
     this.remove()


### PR DESCRIPTION
## References
- fixes #7 
  - should remove the deprecation warning where used downstream

## Changes
- uses quick-and-dirty ternary to handle `leaflet 1` or `2` API changes
  - and won't break on `leaflet 10`! buh, chrome 100.